### PR TITLE
fix: 로딩 상태 테스트 케이스 수정

### DIFF
--- a/src/components/ui/IconButton.test.tsx
+++ b/src/components/ui/IconButton.test.tsx
@@ -58,19 +58,13 @@ describe('IconButton 컴포넌트 테스트', () => {
     expect(button).toBeDisabled();
   });
 
-  it('로딩 상태일 때 모든 자식 요소를 감추고 Spinner를 정상적으로 렌더링해야 합니다.', () => {
+  it('로딩 상태일 때 Spinner를 정상적으로 렌더링해야 합니다.', () => {
     render(<IconButton icon={Home} status="loading" />);
     const button = screen.getByRole('button');
     const spinner = button.querySelector('svg:first-child');
-    const contents = button.querySelectorAll(':not(:first-child)');
 
     expect(button).toHaveAttribute('data-status', 'loading');
     expect(spinner).toBeInTheDocument();
     expect(spinner).toHaveClass('animate-spin');
-    contents.forEach(content => {
-      expect(content).not.toHaveStyle({
-        visibility: 'hidden',
-      });
-    });
   });
 });

--- a/src/components/ui/TextButton.test.tsx
+++ b/src/components/ui/TextButton.test.tsx
@@ -66,19 +66,13 @@ describe('TextButton 컴포넌트 테스트', () => {
     expect(button).toBeDisabled();
   });
 
-  it('로딩 상태일 때 모든 자식 요소를 감추고 Spinner를 정상적으로 렌더링해야 합니다.', () => {
+  it('로딩 상태일 때 Spinner를 정상적으로 렌더링해야 합니다.', () => {
     render(<TextButton label="text-button" status="loading" />);
     const button = screen.getByRole('button');
     const spinner = button.querySelector('svg:first-child');
-    const contents = button.querySelectorAll(':not(:first-child)');
 
     expect(button).toHaveAttribute('data-status', 'loading');
     expect(spinner).toBeInTheDocument();
     expect(spinner).toHaveClass('animate-spin');
-    contents.forEach(content => {
-      expect(content).not.toHaveStyle({
-        visibility: 'hidden',
-      });
-    });
   });
 });


### PR DESCRIPTION
## 상세 내용

### `TextButton`, `IconButton` 컴포넌트
- [x] 로딩 상태 테스트 케이스 스타일 검증 제거
  > - css 적용이 이루어지지 않아 확실한 검증 어려움.
  > - `Spinner`가 표시된다면 나머지 요소들은 잘 숨겨진 것으로 취급할 수 있음. 