### PR TITLE
feat: 대시보드 내용 레이아웃 구현

### DIFF
--- a/src/app/dashboard/counseling/page.tsx
+++ b/src/app/dashboard/counseling/page.tsx
@@ -1,3 +1,7 @@
-export default function Counseling() {
-  return;
+import { INTRO_ITEMS } from 'data';
+
+import { DashboardIntroBox } from 'layouts';
+
+export default function CounselingIntro() {
+  return <DashboardIntroBox {...INTRO_ITEMS.counseling} />;
 }

--- a/src/app/dashboard/feedback/page.tsx
+++ b/src/app/dashboard/feedback/page.tsx
@@ -1,3 +1,7 @@
-export default function Feedback() {
-  return;
+import { INTRO_ITEMS } from 'data';
+
+import { DashboardIntroBox } from 'layouts';
+
+export default function FeedbackIntro() {
+  return <DashboardIntroBox {...INTRO_ITEMS.feedback} />;
 }

--- a/src/app/dashboard/grade/[id]/page.tsx
+++ b/src/app/dashboard/grade/[id]/page.tsx
@@ -1,0 +1,5 @@
+import { DashboardContentBox } from 'layouts';
+
+export default function Grade() {
+  return <DashboardContentBox>{null}</DashboardContentBox>;
+}

--- a/src/app/dashboard/grade/page.tsx
+++ b/src/app/dashboard/grade/page.tsx
@@ -1,3 +1,7 @@
-export default function Grade() {
-  return;
+import { INTRO_ITEMS } from 'data';
+
+import { DashboardIntroBox } from 'layouts';
+
+export default function GradeIntro() {
+  return <DashboardIntroBox {...INTRO_ITEMS.grade} />;
 }

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -23,10 +23,10 @@ export default function DashboardLayout({
       <SideNav />
       <main className="relative size-full">
         <PageHeader />
-        <section className="relative -top-28 flex h-[calc(100vh-64px-128px)] w-full px-8">
+        <section className="relative -top-28 flex h-[calc(100vh-64px-128px)] w-full gap-x-8 px-8">
           <StudentList initialData={dummyData} />
+          {children}
         </section>
-        {children}
       </main>
     </>
   );

--- a/src/app/dashboard/report/page.tsx
+++ b/src/app/dashboard/report/page.tsx
@@ -1,3 +1,7 @@
-export default function Report() {
-  return;
+import { INTRO_ITEMS } from 'data';
+
+import { DashboardIntroBox } from 'layouts';
+
+export default function ReportIntro() {
+  return <DashboardIntroBox {...INTRO_ITEMS.report} />;
 }

--- a/src/app/dashboard/student-info/page.tsx
+++ b/src/app/dashboard/student-info/page.tsx
@@ -1,3 +1,7 @@
-export default function StudentInfo() {
-  return;
+import { INTRO_ITEMS } from 'data';
+
+import { DashboardIntroBox } from 'layouts';
+
+export default function StudentInfoIntro() {
+  return <DashboardIntroBox {...INTRO_ITEMS['student-info']} />;
 }

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -2,9 +2,20 @@ import { Chart, Comment, Heart, Home, Layer, User } from 'assets/icons';
 
 import type { WithIconComponent } from 'types';
 
+type PageCategories =
+  | 'grade'
+  | 'student-info'
+  | 'feedback'
+  | 'counseling'
+  | 'report';
+
 interface NavItem extends Required<WithIconComponent> {
   path: string;
   title: string;
+}
+
+interface IntroItem extends Pick<NavItem, 'icon'> {
+  description: string;
 }
 
 export const NAV_ITEMS: NavItem[] = [
@@ -15,3 +26,28 @@ export const NAV_ITEMS: NavItem[] = [
   { path: '/dashboard/counseling', title: '상담', icon: Heart },
   { path: '/dashboard/report', title: '보고서', icon: Layer },
 ];
+
+export const INTRO_ITEMS: {
+  [category in PageCategories]: IntroItem;
+} = {
+  grade: {
+    icon: Chart,
+    description: '학생들의 노력과 성장을 기록합니다.',
+  },
+  'student-info': {
+    icon: User,
+    description: '학생들의 학교 생활과 활동을 기록합니다.',
+  },
+  feedback: {
+    icon: Comment,
+    description: '학생들에 관한 다양한 피드백을 기록합니다.',
+  },
+  counseling: {
+    icon: Heart,
+    description: '학생들의 심리적 안정을 위한 상담을 기록합니다.',
+  },
+  report: {
+    icon: Layer,
+    description: '학생들의 기록을 정성껏 모아 맞춤형 보고서를 제공합니다.',
+  },
+};

--- a/src/layouts/DashboardContentBox.stories.tsx
+++ b/src/layouts/DashboardContentBox.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import DashboardContentBox from './DashboardContentBox';
+
+const meta = {
+  title: 'Layouts/DashboardContentBox',
+  tags: ['autodocs'],
+  component: DashboardContentBox,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof DashboardContentBox>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="h-screen w-full p-20">
+      <DashboardContentBox />
+    </div>
+  ),
+};

--- a/src/layouts/DashboardContentBox.test.tsx
+++ b/src/layouts/DashboardContentBox.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react';
+
+import DashboardContentBox from './DashboardContentBox';
+
+describe('DashboardContentBox 레이아웃 컴포넌트 테스트', () => {
+  it('컴포넌트를 정상적으로 렌더링해야 합니다.', () => {
+    const { container } = render(<DashboardContentBox />);
+
+    expect(container).toBeInTheDocument();
+  });
+
+  it('props를 정상적으로 전달해야 합니다.', () => {
+    const { container } = render(
+      <DashboardContentBox>content</DashboardContentBox>,
+    );
+    const contentBox = container.querySelector('div');
+
+    expect(contentBox).toHaveTextContent('content');
+  });
+});

--- a/src/layouts/DashboardContentBox.tsx
+++ b/src/layouts/DashboardContentBox.tsx
@@ -1,0 +1,9 @@
+const DashboardContentBox = ({ children }: React.PropsWithChildren) => {
+  return (
+    <div className="shadow-drop bg-default size-full rounded-md p-8">
+      {children}
+    </div>
+  );
+};
+
+export default DashboardContentBox;

--- a/src/layouts/DashboardIntroBox.stories.tsx
+++ b/src/layouts/DashboardIntroBox.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { INTRO_ITEMS } from 'data';
+
+import DashboardIntroBox from './DashboardIntroBox';
+
+const meta = {
+  title: 'Layouts/DashboardIntroBox',
+  tags: ['autodocs'],
+  component: DashboardIntroBox,
+  args: {
+    ...INTRO_ITEMS.grade,
+  },
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof DashboardIntroBox>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const DashboardIntroBoxRender = ({
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DashboardIntroBox>) => (
+  <div className="h-screen w-full p-20">
+    <DashboardIntroBox {...props} />
+  </div>
+);
+
+export const Grade: Story = {
+  render: ({ ...props }) => <DashboardIntroBoxRender {...props} />,
+};
+
+export const StudentInfo: Story = {
+  args: {
+    ...INTRO_ITEMS['student-info'],
+  },
+  render: ({ ...props }) => <DashboardIntroBoxRender {...props} />,
+};
+
+export const Feedback: Story = {
+  args: {
+    ...INTRO_ITEMS.feedback,
+  },
+  render: ({ ...props }) => <DashboardIntroBoxRender {...props} />,
+};
+
+export const Counseling: Story = {
+  args: {
+    ...INTRO_ITEMS.counseling,
+  },
+  render: ({ ...props }) => <DashboardIntroBoxRender {...props} />,
+};
+
+export const Report: Story = {
+  args: {
+    ...INTRO_ITEMS.report,
+  },
+  render: ({ ...props }) => <DashboardIntroBoxRender {...props} />,
+};

--- a/src/layouts/DashboardIntroBox.test.tsx
+++ b/src/layouts/DashboardIntroBox.test.tsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react';
+
+import { Check } from 'assets/icons';
+
+import { INTRO_ITEMS } from 'data';
+
+import DashboardIntroBox from './DashboardIntroBox';
+
+describe('DashboardIntroBox 레이아웃 컴포넌트 테스트', () => {
+  it('컴포넌트를 정상적으로 렌더링해야 합니다.', () => {
+    const { container } = render(<DashboardIntroBox {...INTRO_ITEMS.grade} />);
+
+    expect(container).toBeInTheDocument();
+  });
+
+  it('props를 정상적으로 전달해야 합니다.', () => {
+    const { container } = render(
+      <DashboardIntroBox icon={Check} description="description" />,
+    );
+    const introBox = container.querySelector('div');
+
+    expect(introBox?.firstElementChild?.firstElementChild?.tagName).toBe('svg');
+    expect(introBox).toHaveTextContent('description');
+  });
+});

--- a/src/layouts/DashboardIntroBox.tsx
+++ b/src/layouts/DashboardIntroBox.tsx
@@ -1,0 +1,22 @@
+import type { WithIconComponent } from 'types';
+
+import { Icon } from 'components/ui';
+
+import DashboardContentBox from './DashboardContentBox';
+
+interface DashboardIntroBoxProps extends Required<WithIconComponent> {
+  description: string;
+}
+
+const DashboardIntroBox = ({ icon, description }: DashboardIntroBoxProps) => {
+  return (
+    <DashboardContentBox>
+      <div className="*:opacity-off flex size-full flex-col items-center justify-center gap-y-8 stroke-current">
+        <Icon src={icon} size={48} className="scale-150" />
+        <p className="text-center font-semibold text-pretty">{description}</p>
+      </div>
+    </DashboardContentBox>
+  );
+};
+
+export default DashboardIntroBox;

--- a/src/layouts/index.ts
+++ b/src/layouts/index.ts
@@ -1,4 +1,5 @@
 export { default as DashboardContentBox } from './DashboardContentBox';
+export { default as DashboardIntroBox } from './DashboardIntroBox';
 export { default as Header } from './Header';
 export { default as PageHeader } from './PageHeader';
 export { default as SideNav } from './SideNav';

--- a/src/layouts/index.ts
+++ b/src/layouts/index.ts
@@ -1,3 +1,4 @@
+export { default as DashboardContentBox } from './DashboardContentBox';
 export { default as Header } from './Header';
 export { default as PageHeader } from './PageHeader';
 export { default as SideNav } from './SideNav';


### PR DESCRIPTION
## 상세 내용

- [x] `/dashboard` 자식 요소 위치 변경
- [x] `DashboardContentBox` 레이아웃 컴포넌트 구현
- [x] `DashboardIntroBox` 레이아웃 컴포넌트 구현