### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main # 기본 브랜치
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/inu-software-design-team/frontend/security/code-scanning/5](https://github.com/inu-software-design-team/frontend/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimum permissions required for the workflow to function correctly. Based on the workflow steps:
1. The `actions/checkout@v4` step requires `contents: read` to check out the repository code.
2. The `curl` command in the last step uses a personal access token (`secrets.TOKEN_DEPLOY`) to trigger a repository dispatch event, which does not require additional permissions for the `GITHUB_TOKEN`.

Thus, the minimal permissions block will be:
```yaml
permissions:
  contents: read
```

This ensures the workflow has only read access to the repository contents and no unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
