### PR TITLE
fix: TypeError about `toSorted`

### DIFF
--- a/src/features/grades/components/actions.ts
+++ b/src/features/grades/components/actions.ts
@@ -24,7 +24,7 @@ export const getYearListForGrade = async ({
   if (!response.ok) throw new Error(response.statusText);
   const { yearSelection }: { yearSelection: number[] } = await response.json();
 
-  return yearSelection.toSorted((a, b) => b - a);
+  return yearSelection.sort((a, b) => b - a);
 };
 
 export const getGradeList = async ({
@@ -94,7 +94,7 @@ export const getGradeList = async ({
     );
   }
 
-  return gradeList.toSorted((a, b) => {
+  return gradeList.sort((a, b) => {
     if (a.year !== b.year) return b.year - a.year;
     if (a.semester !== b.semester) return a.semester < b.semester ? 1 : -1;
     if (a.term !== b.term) return a.term < b.term ? -1 : 1;
@@ -122,7 +122,7 @@ export const getOptionsForGrade = async ({
     year: [
       { id: crypto.randomUUID(), value: '전체', default: true },
       ...Array.from(new Set(years))
-        .toSorted((a, b) => b - a)
+        .sort((a, b) => b - a)
         .map(year => ({
           id: crypto.randomUUID(),
           value: year.toString(),
@@ -140,7 +140,7 @@ export const getOptionsForGrade = async ({
     term: [
       { id: crypto.randomUUID(), value: '전체', default: true },
       ...Array.from(new Set(grades.flatMap(({ term }) => TERMS[term])))
-        .toSorted((a, b) => (a < b ? 1 : -1))
+        .sort((a, b) => (a < b ? 1 : -1))
         .map(value => ({
           id: crypto.randomUUID(),
           value,

--- a/src/features/grades/contexts/GradeItemManagerContext.tsx
+++ b/src/features/grades/contexts/GradeItemManagerContext.tsx
@@ -65,7 +65,7 @@ export const GradeItemManagerProvider = ({
         ...added,
         ...removed,
         ...updated,
-      ].toSorted((a, b) => {
+      ].sort((a, b) => {
         if (a.year !== b.year) return b.year - a.year;
         if (a.semester !== b.semester) return a.semester < b.semester ? 1 : -1;
         if (a.term !== b.term) return a.term < b.term ? 1 : -1;

--- a/src/features/students/components/actions.ts
+++ b/src/features/students/components/actions.ts
@@ -19,7 +19,7 @@ export const getYearListForStudent = async (): Promise<
   const { yearSelection }: { yearSelection: number[] } = await response.json();
 
   return yearSelection
-    .toSorted((a, b) => b - a)
+    .sort((a, b) => b - a)
     .map(year => ({
       id: crypto.randomUUID(),
       year,

--- a/src/generate-icons.ts
+++ b/src/generate-icons.ts
@@ -84,7 +84,7 @@ const exportStatementsForDataIndex = [
         line =>
           line.startsWith('export * from') && !line.endsWith("'./icon';\r"),
       ),
-  ].toSorted((a, b) => (a > b ? 1 : -1)),
+  ].sort((a, b) => (a > b ? 1 : -1)),
   ...fs
     .readFileSync(DATA_INDEX_FILE)
     .toString()


### PR DESCRIPTION
This pull request replaces the use of the `toSorted` method with the standard `sort` method across multiple files for compatibility and consistency. The changes primarily affect sorting operations in various functions related to grades, students, and icon generation.

### Changes in sorting operations:

* **Grades-related functions**:
  - Replaced `toSorted` with `sort` in `getYearListForGrade`, `getGradeList`, and `getOptionsForGrade` to handle sorting of year selections, grade lists, and grade options. (`src/features/grades/components/actions.ts`: [[1]](diffhunk://#diff-95ecdff269434e740f9c5733fbb2f067100f5e2810a12a7e362ede4f9331fc81L27-R27) [[2]](diffhunk://#diff-95ecdff269434e740f9c5733fbb2f067100f5e2810a12a7e362ede4f9331fc81L97-R97) [[3]](diffhunk://#diff-95ecdff269434e740f9c5733fbb2f067100f5e2810a12a7e362ede4f9331fc81L125-R125) [[4]](diffhunk://#diff-95ecdff269434e740f9c5733fbb2f067100f5e2810a12a7e362ede4f9331fc81L143-R143)
  - Updated sorting logic in `GradeItemManagerProvider` to use `sort` for managing grade items. (`src/features/grades/contexts/GradeItemManagerContext.tsx`: [src/features/grades/contexts/GradeItemManagerContext.tsxL68-R68](diffhunk://#diff-42fc920d933216c7edf58cb1a5f796aa3d14a8a4f1c6d3260a5ac32b518f9c58L68-R68))

* **Students-related functions**:
  - Replaced `toSorted` with `sort` in `getYearListForStudent` for sorting year selections. (`src/features/students/components/actions.ts`: [src/features/students/components/actions.tsL22-R22](diffhunk://#diff-6af06d331bfe9a3c2ef77d770db12cdc71f5daceb85e7f49663eef1478a7f2f3L22-R22))

* **Icon generation**:
  - Updated sorting logic in `exportStatementsForDataIndex` to use `sort` for ordering export statements. (`src/generate-icons.ts`: [src/generate-icons.tsL87-R87](diffhunk://#diff-72014e67fac9bc28a18bcd26aec8ad91bbaf22f4cc4e6ca573dceae96dac2c5fL87-R87))